### PR TITLE
Update timing event category filter (fixes app in Chrome Canary)

### DIFF
--- a/src/components/TimelineFilters.js
+++ b/src/components/TimelineFilters.js
@@ -51,5 +51,5 @@ export function _filterEventsForDomInteractive (e) {
 }
 
 export function _filterEventsForFirstTextPaint (e) {
-  return e.categoriesString.includes('blink.user_timing') && e.name === 'firstTextPaint' && e.args.frame === ourframe
+  return e.categoriesString.includes('devtools.timeline') && e.name === 'firstTextPaint' && e.args.frame === ourframe
 }


### PR DESCRIPTION
It changes the filter keyword to match the `firstTextPaint` that now is under a different caterory. This fix the errors in the app on latest Chrome versions (tested in Canary)

Based on this source code: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/core/paint/PaintTiming.cpp